### PR TITLE
Add Flask snake game with styled UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# snake
+# Flask Snake
+
+A simple snake game served with [Flask](https://flask.palletsprojects.com/). The game is rendered on an HTML canvas and controlled with the arrow keys.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install flask
+   ```
+2. Start the development server:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser to play.
+
+## Controls
+
+Use the arrow keys to move the snake. Eat the red apples to grow. Avoid running into yourself!
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,13 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    """Serve the main game page."""
+    return render_template("index.html")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/static/snake.js
+++ b/static/snake.js
@@ -1,0 +1,107 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const grid = 20;
+let count = 0;
+let score = 0;
+
+const snake = {
+  x: 160,
+  y: 160,
+  dx: grid,
+  dy: 0,
+  cells: [],
+  maxCells: 4
+};
+
+const apple = {
+  x: 320,
+  y: 320
+};
+
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+function resetApple() {
+  apple.x = getRandomInt(0, 20) * grid;
+  apple.y = getRandomInt(0, 20) * grid;
+}
+
+function loop() {
+  requestAnimationFrame(loop);
+
+  if (++count < 4) {
+    return;
+  }
+  count = 0;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  snake.x += snake.dx;
+  snake.y += snake.dy;
+
+  if (snake.x < 0) {
+    snake.x = canvas.width - grid;
+  } else if (snake.x >= canvas.width) {
+    snake.x = 0;
+  }
+
+  if (snake.y < 0) {
+    snake.y = canvas.height - grid;
+  } else if (snake.y >= canvas.height) {
+    snake.y = 0;
+  }
+
+  snake.cells.unshift({x: snake.x, y: snake.y});
+
+  if (snake.cells.length > snake.maxCells) {
+    snake.cells.pop();
+  }
+
+  ctx.fillStyle = 'red';
+  ctx.fillRect(apple.x, apple.y, grid - 1, grid - 1);
+
+  ctx.fillStyle = '#0f0';
+  snake.cells.forEach(function(cell, index) {
+    ctx.fillRect(cell.x, cell.y, grid - 1, grid - 1);
+
+    if (cell.x === apple.x && cell.y === apple.y) {
+      snake.maxCells++;
+      score++;
+      document.getElementById('score').textContent = score;
+      resetApple();
+    }
+
+    for (let i = index + 1; i < snake.cells.length; i++) {
+      if (cell.x === snake.cells[i].x && cell.y === snake.cells[i].y) {
+        snake.x = 160;
+        snake.y = 160;
+        snake.cells = [];
+        snake.maxCells = 4;
+        snake.dx = grid;
+        snake.dy = 0;
+        score = 0;
+        document.getElementById('score').textContent = score;
+        resetApple();
+      }
+    }
+  });
+}
+
+resetApple();
+requestAnimationFrame(loop);
+
+document.addEventListener('keydown', function(e) {
+  if (e.key === 'ArrowLeft' && snake.dx === 0) {
+    snake.dx = -grid;
+    snake.dy = 0;
+  } else if (e.key === 'ArrowUp' && snake.dy === 0) {
+    snake.dy = -grid;
+    snake.dx = 0;
+  } else if (e.key === 'ArrowRight' && snake.dx === 0) {
+    snake.dx = grid;
+    snake.dy = 0;
+  } else if (e.key === 'ArrowDown' && snake.dy === 0) {
+    snake.dy = grid;
+    snake.dx = 0;
+  }
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,25 @@
+body {
+    background-color: #1e1e1e;
+    color: #eee;
+    font-family: Arial, Helvetica, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.game-wrapper {
+    text-align: center;
+}
+
+canvas {
+    background-color: #111;
+    border: 4px solid #555;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.score-board {
+    margin-top: 10px;
+    font-size: 1.2rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flask Snake</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  </head>
+  <body>
+    <div class="game-wrapper">
+      <h1>Snake</h1>
+      <canvas id="game" width="400" height="400"></canvas>
+      <div class="score-board">Score: <span id="score">0</span></div>
+    </div>
+    <script src="{{ url_for('static', filename='snake.js') }}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app serving a canvas-based snake game
- style game UI and implement game logic with JavaScript
- document setup and controls in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_689e4af56df483329036a811774e0694